### PR TITLE
Added dbversion to check for schema changes

### DIFF
--- a/src/Controller/ObjectDetailController.php
+++ b/src/Controller/ObjectDetailController.php
@@ -134,7 +134,7 @@ class ObjectDetailController extends AbstractController{
                    $new_object->setNotiz($info['notiz']);
                    $new_object->setKategorie($info['kategorie_id']);
                    $new_object->setZeitstempelumsetzung($info['dueDate']);
-
+                   
                    
                    $new_object->setNutzer($em->getRepository(Nutzer::class)->findOneBy(array('id' => $usr->getId())));
 
@@ -746,11 +746,15 @@ class ObjectDetailController extends AbstractController{
         $hist->setReserviertVon($object->getreserviertVon());
         $hist->setStandort($object->getStandort());
         $hist->setZeitstempelumsetzung($object->getZeitstempelumsetzung());
-        // Veraenderte Daten
+        // Changed Data
         $hist->setStatusId(Objekt::STATUS_EDITIERT);
         $hist->setVerwendung($newVerwendung);
         $hist->setSystemaktion(true);
         $hist->setZeitstempel(new \DateTime("now"));
+
+        // This new historyentry needs a new dbversion and cannot use the old version schema 
+        $hist->setDBVersion(Objekt::CURRENT_DB_VERSION);
+
 
         foreach($object->getImages() as $image){
             $hist->addImage($image);
@@ -951,6 +955,7 @@ class ObjectDetailController extends AbstractController{
 
         $new_status = $status_id;
         
+        $object->updateDBVersion();
         $object->setSystemaktion($isSystemaktion);
 
         $object->setZeitstempel(new \DateTime('now'));

--- a/src/Entity/HistorieObjekt.php
+++ b/src/Entity/HistorieObjekt.php
@@ -74,6 +74,16 @@ class HistorieObjekt
     #[ORM\InverseJoinColumn(name: 'barcode_id', referencedColumnName: 'barcode_id')]
     private $images;
 
+
+    // In dieser Variable wird die Version der DB dokumentiert, damit im Nachgang nachvollzogen werden kann,
+    // nach welchen Regeln der Eintrag erfolgt ist.
+    // Diese Variable wird im Konstruktor gesetzt und wird nicht nachtraeglich veraendert
+    #[ORM\Column(type: "text")]
+    protected $dbversion;
+
+
+
+
     public function __construct($barcode_id)
     {
         $this->barcode_id = $barcode_id;
@@ -313,4 +323,17 @@ class HistorieObjekt
     {
         return $this->images;
     }
+
+
+    public function getDBVersion()
+    {
+        return $this->dbversion;
+    }
+
+    public function setDBVersion($dbversion)
+    {
+        $this->dbversion = $dbversion;
+    }
+
+
 }

--- a/src/Entity/Objekt.php
+++ b/src/Entity/Objekt.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: "ams_Objekt")]
 class Objekt
 {
+    const CURRENT_DB_VERSION = "1.0";
     const KATEGORIE_ASSERVAT = 0;
     const KATEGORIE_AUSRUESTUNG = 1;
     const KATEGORIE_BEHAELTER = 2;
@@ -98,6 +99,9 @@ class Objekt
         
         $this->HDDs = new \Doctrine\Common\Collections\ArrayCollection();
         $this->Images = new \Doctrine\Common\Collections\ArrayCollection();
+
+        // Setting dbversion is required for phpunit testing
+        $this->dbversion = Objekt::CURRENT_DB_VERSION;
         
     }
 
@@ -106,7 +110,7 @@ class Objekt
     #[ORM\OneToMany(targetEntity:"Objekt",mappedBy:"standort")]
     protected $barcode_id;
 
-    
+
     #[ORM\Column(type: "text")]
     protected $name;
     
@@ -175,7 +179,11 @@ class Objekt
     #[ORM\OneToOne(targetEntity: "ObjektBlob", mappedBy:"objekt",cascade: ["persist", "remove"])]
     protected $objektBlob;
     
-    
+    // In dieser Variable wird die Version der DB dokumentiert, damit im Nachgang nachvollzogen werden kann,
+    // nach welchen Regeln der Eintrag erfolgt ist.
+    // Diese Variable wird im Konstruktor gesetzt und wird nicht nachtraeglich veraendert
+    #[ORM\Column(type: "text")]
+    protected $dbversion;
 
     
   
@@ -704,6 +712,16 @@ class Objekt
         return $this->systemaktion;
     }
     
+    // Diese Methode setzt im Objekt die aktuell DB Version
+    // Dies ist notwendig, wenn sich Datenbankschema aendert
+    public function updateDBVersion(){
+        $this->dbversion = Objekt::CURRENT_DB_VERSION;
+    }
+
+    public function getDBVersion(){
+        return $this->dbversion;
+    }
+
     
 
     public function isObjectWithNewStatusValid( $newstatus, 
@@ -931,6 +949,7 @@ class Objekt
         $hist->setZeitstempel($this->getZeitstempel());
         $hist->setZeitstempelumsetzung($this->getZeitstempelumsetzung());
         $hist->setSystemaktion($this->GetSystemaktion());
+        $hist->setDBVersion($this->getDBVersion());
         
         
         foreach($this->getImages() as $image){

--- a/tests/Factory/ObjektFactory.php
+++ b/tests/Factory/ObjektFactory.php
@@ -114,6 +114,7 @@ final class ObjektFactory extends PersistentProxyObjectFactory
             'zeitstempel' => self::faker()->dateTime(),
             'zeitstempelumsetzung' => self::faker()->dateTime(),
             'nutzer' => LazyValue::memoize(fn () => NutzerFactory::createOne()),
+            
         ];
 
         return $defaults;


### PR DESCRIPTION
In diesem PR wird künftig eine festgeschriebene dbversion in die Objekt, als auch Historientabellen eingebettet, in welchem die zum Zeitpunkt genutztes DB-Schema protokolliert wird. Dies ist im Hintergrund relevant, um nachzuvollziehen, mit welchen bestehenden Regeln der konkrete Eintrag erstellt worden ist. 

Dies ist in Fällen relevant, wo sich die Bedeutung der jeweiligen Aktion mit der Zeit verändern und gegebenenfalls in einer neueren Version anders gehandhabt werden können.

Um den Code Testen zu können, müssen auf Datenbankebene folgende Änderungen vorgenommen werden:
`ALTER TABLE ams_Historie_Objekt ADD dbversion LONGTEXT NOT NULL;`  
`ALTER TABLE ams_Objekt ADD dbversion LONGTEXT NOT NULL;`
`update ams_Objekt set dbversion="0.9";`  
`update ams_Historie_Objekt set dbversion="0.9";`
In der konkreten Migration müsste der Defaultwert auf "1.0" gesetzt werden.


Diese PR wird für anderweitige PRs benötigt, die konkrete Änderungen am Datenbankschema durchführen, sodass nicht alle potentiell relevanten Funktionen enthalten sind:

-  Sicht der Versionsangabe in den Details des jeweiligen Objekts
-  Eine Informationsseite mit dokumentierten Änderungen des Datenbankschema bzw. deren Auswirkungen
  
